### PR TITLE
tern: Pass the `path` of the current type to plugins

### DIFF
--- a/docworks-tern/lib/plugins.js
+++ b/docworks-tern/lib/plugins.js
@@ -1,9 +1,9 @@
-export function runPlugins(plugins, pluginFunction, extra, tern) {
+export function runPlugins(plugins, pluginFunction, extra, tern, path) {
   extra = extra || {};
   if (plugins) {
     plugins.filter(plugin => !!plugin[pluginFunction] && !!plugin.extendDocworksKey)
       .forEach(plugin => {
-        plugin[pluginFunction](extra[plugin.extendDocworksKey], tern);
+        plugin[pluginFunction](extra[plugin.extendDocworksKey], tern, path);
       })
   }
 }

--- a/docworks-tern/lib/tern-generator.js
+++ b/docworks-tern/lib/tern-generator.js
@@ -48,7 +48,8 @@ export function propTern(service, prop, urlGenerator, plugins) {
       "!url": urlGenerator(service, propName)
     };
 
-  runPlugins(plugins, 'ternProperty', prop.extra, tern[propName]);
+  const propPath = `${service.name}.${propName}`;
+  runPlugins(plugins, 'ternProperty', prop.extra, tern[propName], propPath);
 
   return tern;
 }
@@ -85,7 +86,8 @@ export function operationTern(service, operation, urlGenerator, findCallback, pl
     "!url": urlGenerator(service, operationName)
   };
 
-  runPlugins(plugins, 'ternOperation', operation.extra, tern[operationName]);
+  const operationPath = `${service.name}.${operationName}`;
+  runPlugins(plugins, 'ternOperation', operation.extra, tern[operationName], operationPath);
 
   return tern;
 }
@@ -108,7 +110,9 @@ export function messageTern(service, message, urlGenerator, plugins) {
      }
   });
 
-  runPlugins(plugins, 'ternMessage', message.extra, tern[messageName]);
+  const messagePath = `${service.name}.${messageName}`;
+  runPlugins(plugins, 'ternMessage', message.extra, tern[messageName], messagePath);
+
 
   return tern;
 }


### PR DESCRIPTION
To allow path-based transformations